### PR TITLE
Favor using full colors instead of light for Material Ui Next beta 30

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -170,11 +170,32 @@
         "redux": "3.7.2"
       }
     },
+    "@types/jss": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@types/jss/-/jss-9.3.0.tgz",
+      "integrity": "sha512-n7MUYCO/Wt4d6Yj0ZewXSSkqBcrdLFgpQ4mUBRXBWDmLfXtgT3tJ26GVPr8HiyRLLze6iQfaBJTlvjRTjgZpRg==",
+      "dev": true
+    },
     "@types/node": {
       "version": "6.0.89",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.89.tgz",
       "integrity": "sha512-Z/67L97+6H1qJiEEHSN1SQapkWjDss1D90rAnFcQ6UxKkah9juzotK5UNEP1bDv/0lJ3NAQTnVfc/JWdgCGruA==",
       "dev": true
+    },
+    "@types/react": {
+      "version": "16.0.34",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.0.34.tgz",
+      "integrity": "sha512-Ee66fX2qMsDnDq7sPnDtq1bGoo479j6Fo1BlSnne+L5rp6ndzBUgz72+MRNuN56zg9uuteRCkJAMdDJEX2Uqig==",
+      "dev": true
+    },
+    "@types/react-transition-group": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-2.0.6.tgz",
+      "integrity": "sha512-mVhRv+d0MIoLWl6hEFA7Nnd/obW2RQpZViTAKhM37mltuTDWCdoj8xAZv94ntB8wgAc6DDiDCXxFXPgClGnsfQ==",
+      "dev": true,
+      "requires": {
+        "@types/react": "16.0.34"
+      }
     },
     "@webpack-blocks/assets": {
       "version": "1.0.0-rc",
@@ -3835,17 +3856,6 @@
         "sha.js": "2.4.9"
       }
     },
-    "create-react-class": {
-      "version": "15.6.2",
-      "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.2.tgz",
-      "integrity": "sha1-zx7RXxKq1/FO9fLf4F5sQvke8Co=",
-      "dev": true,
-      "requires": {
-        "fbjs": "0.8.16",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1"
-      }
-    },
     "cross-spawn": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
@@ -4286,12 +4296,6 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-      "dev": true
-    },
-    "deepmerge": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-1.5.2.tgz",
-      "integrity": "sha512-95k0GDqvBjZavkuvzx/YqVLv/6YYa17fz6ILMSf7neqQITCPbnfEnQvEgMPNjH4kgobe7+WIL0yJEHku+H3qtQ==",
       "dev": true
     },
     "default-require-extensions": {
@@ -7960,21 +7964,6 @@
       "integrity": "sha512-U1Oi1h45vFRuISr+g1DQ3Oua7CkNKNs47fTdiT/lHkuBMc6BBDUbPv9IbPPhk9gsEaX45Iy9TX8CAuaHLPCfEA==",
       "dev": true
     },
-    "jss-expand": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/jss-expand/-/jss-expand-4.0.1.tgz",
-      "integrity": "sha512-LRIMXXChAOgnhwSqYLJg8MS6dI98bf/sg52pAg04pbjOAtjfzyS0JTnQAiyk3PxqR3nKFR/Yv44ahpIpkdcxVA==",
-      "dev": true
-    },
-    "jss-extend": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/jss-extend/-/jss-extend-5.0.0.tgz",
-      "integrity": "sha512-fUp+9KipbdmzSfTxNHoT3mrFnE7fYn7EyHg3LTUexfpWrwj5Afkwb3iCfYV7GYCpg9OKDsqc18atwjHvSPWWKg==",
-      "dev": true,
-      "requires": {
-        "warning": "3.0.0"
-      }
-    },
     "jss-global": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/jss-global/-/jss-global-2.0.0.tgz",
@@ -7996,45 +7985,13 @@
         "warning": "3.0.0"
       }
     },
-    "jss-preset-default": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/jss-preset-default/-/jss-preset-default-3.0.0.tgz",
-      "integrity": "sha512-5wRsHsV89XjnQlUVN5jQfo6gcfcirDJmsMJL52HmWoQlV9SA+jhUtt1w3LjcJHe4e3tX4u/To/x3Btmhi+LZtQ==",
+    "jss-template": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/jss-template/-/jss-template-1.0.1.tgz",
+      "integrity": "sha512-m5BqEWha17fmIVXm1z8xbJhY6GFJxNB9H68GVnCWPyGYfxiAgY9WTQyvDAVj+pYRgrXSOfN5V1T4+SzN1sJTeg==",
       "dev": true,
       "requires": {
-        "jss-camel-case": "5.0.0",
-        "jss-compose": "4.0.0",
-        "jss-default-unit": "7.0.0",
-        "jss-expand": "4.0.1",
-        "jss-extend": "5.0.0",
-        "jss-global": "2.0.0",
-        "jss-nested": "5.0.0",
-        "jss-props-sort": "5.0.0",
-        "jss-vendor-prefixer": "6.0.0"
-      }
-    },
-    "jss-props-sort": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/jss-props-sort/-/jss-props-sort-5.0.0.tgz",
-      "integrity": "sha512-xtoVE7BlcPaMN/dzypHPYJn+QiphLPB1skypAOp9zLkOozPbR/x0JVAFdZnd7zqmmjvg+Ma/txjSg0HN/eZsGA==",
-      "dev": true
-    },
-    "jss-rtl": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/jss-rtl/-/jss-rtl-0.2.0.tgz",
-      "integrity": "sha512-+wx3gOOpUVdT3ArcWZggUiEdunFmxRlDXUoYGLMVJeT8KKrO5K4io3vIbm1r42YkMIiYJrklwQ2HIMc8Zzp5tA==",
-      "dev": true,
-      "requires": {
-        "rtl-css-js": "1.7.0"
-      }
-    },
-    "jss-vendor-prefixer": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/jss-vendor-prefixer/-/jss-vendor-prefixer-6.0.0.tgz",
-      "integrity": "sha512-leqW7B2QLXYsUNR3jsUZP3CkuOYcWXyfF8TSJc4XNxhVCNH7ztK5dcnF8nLoMnxT0w/ajloeJKcch2ty/viCAA==",
-      "dev": true,
-      "requires": {
-        "css-vendor": "0.3.8"
+        "warning": "3.0.0"
       }
     },
     "jsx-ast-utils": {
@@ -8440,33 +8397,194 @@
       }
     },
     "material-ui": {
-      "version": "1.0.0-beta.16",
-      "resolved": "https://registry.npmjs.org/material-ui/-/material-ui-1.0.0-beta.16.tgz",
-      "integrity": "sha1-4THB9xcHpnYIfwYuNKyUr7hdgr8=",
+      "version": "1.0.0-beta.30",
+      "resolved": "https://registry.npmjs.org/material-ui/-/material-ui-1.0.0-beta.30.tgz",
+      "integrity": "sha512-cgUUYf+sXjkUQmImjngHPmwo6kBIfvZKrNxmp56cpATYyaeoBydfERwv9SfUu1zzJyXLhJ6tt17XeUBn8aSqug==",
       "dev": true,
       "requires": {
+        "@types/jss": "9.3.0",
+        "@types/react-transition-group": "2.0.6",
         "babel-runtime": "6.26.0",
         "brcast": "3.0.1",
         "classnames": "2.2.5",
-        "deepmerge": "1.5.2",
+        "deepmerge": "2.0.1",
         "dom-helpers": "3.2.1",
-        "hoist-non-react-statics": "1.2.0",
-        "jss": "8.1.0",
-        "jss-preset-default": "3.0.0",
-        "jss-rtl": "0.2.0",
+        "hoist-non-react-statics": "2.3.1",
+        "jss": "9.5.1",
+        "jss-camel-case": "6.0.0",
+        "jss-default-unit": "8.0.2",
+        "jss-global": "3.0.0",
+        "jss-nested": "6.0.1",
+        "jss-props-sort": "6.0.0",
+        "jss-vendor-prefixer": "7.0.0",
         "keycode": "2.1.9",
         "lodash": "4.17.4",
-        "normalize-scroll-left": "0.1.1",
+        "normalize-scroll-left": "0.1.2",
         "prop-types": "15.6.0",
         "react-event-listener": "0.5.1",
-        "react-flow-types": "0.2.0-beta.2",
-        "react-jss": "7.2.0",
-        "react-popper": "0.7.3",
+        "react-jss": "8.2.1",
+        "react-popper": "0.7.5",
         "react-scrollbar-size": "2.0.2",
         "react-transition-group": "2.2.1",
         "recompose": "0.26.0",
         "scroll": "2.0.1",
         "warning": "3.0.0"
+      },
+      "dependencies": {
+        "deepmerge": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.0.1.tgz",
+          "integrity": "sha512-VIPwiMJqJ13ZQfaCsIFnp5Me9tnjURiaIFxfz7EH0Ci0dTSQpZtSLrqOicXqEd/z2r+z+Klk9GzmnRsgpgbOsQ==",
+          "dev": true
+        },
+        "hoist-non-react-statics": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.3.1.tgz",
+          "integrity": "sha1-ND24TGAYxlB3iJgkATWhQg7iLOA=",
+          "dev": true
+        },
+        "jss": {
+          "version": "9.5.1",
+          "resolved": "https://registry.npmjs.org/jss/-/jss-9.5.1.tgz",
+          "integrity": "sha512-py//ogG1xeztpEDmosJtrkfUXibx3qiAr+1GQvfLHp7azpqkzTPLCnainDgH7Zn0q6S7rcM1eINrVT9n/r5f2w==",
+          "dev": true,
+          "requires": {
+            "is-in-browser": "1.1.3",
+            "symbol-observable": "1.1.0",
+            "warning": "3.0.0"
+          }
+        },
+        "jss-camel-case": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/jss-camel-case/-/jss-camel-case-6.0.0.tgz",
+          "integrity": "sha512-XAYa7JpGkLdlLgEfuzSQSVONRzSVvv4Tvyv5H8hLmJuHeFHTWwVrJrW1Cg/buED3izXKwTU2KBGpeXjIR5Eaew==",
+          "dev": true
+        },
+        "jss-compose": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/jss-compose/-/jss-compose-5.0.0.tgz",
+          "integrity": "sha512-YofRYuiA0+VbeOw0VjgkyO380sA4+TWDrW52nSluD9n+1FWOlDzNbgpZ/Sb3Y46+DcAbOS21W5jo6SAqUEiuwA==",
+          "dev": true,
+          "requires": {
+            "warning": "3.0.0"
+          }
+        },
+        "jss-default-unit": {
+          "version": "8.0.2",
+          "resolved": "https://registry.npmjs.org/jss-default-unit/-/jss-default-unit-8.0.2.tgz",
+          "integrity": "sha512-WxNHrF/18CdoAGw2H0FqOEvJdREXVXLazn7PQYU7V6/BWkCV0GkmWsppNiExdw8dP4TU1ma1dT9zBNJ95feLmg==",
+          "dev": true
+        },
+        "jss-expand": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/jss-expand/-/jss-expand-5.1.0.tgz",
+          "integrity": "sha512-WTxmNipgj0V8kr8gc8Gc6Et7uQZH60H7FFNG9zZHjR6TPJoj7TDK+/EBxwRHtCRQD4B8RTwoa7MyEKD4ReKfXw==",
+          "dev": true
+        },
+        "jss-extend": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/jss-extend/-/jss-extend-6.1.0.tgz",
+          "integrity": "sha512-bSNwLDOZnMxABsUqvq2lwLJ/MMFs8ThligiLZBOUeyoZCoHqAbcTghvunk2QDVxiOhRTDS57VvhXVJZETW58Bw==",
+          "dev": true,
+          "requires": {
+            "warning": "3.0.0"
+          }
+        },
+        "jss-global": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/jss-global/-/jss-global-3.0.0.tgz",
+          "integrity": "sha512-wxYn7vL+TImyQYGAfdplg7yaxnPQ9RaXY/cIA8hawaVnmmWxDHzBK32u1y+RAvWboa3lW83ya3nVZ/C+jyjZ5Q==",
+          "dev": true
+        },
+        "jss-nested": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/jss-nested/-/jss-nested-6.0.1.tgz",
+          "integrity": "sha512-rn964TralHOZxoyEgeq3hXY8hyuCElnvQoVrQwKHVmu55VRDd6IqExAx9be5HgK0yN/+hQdgAXQl/GUrBbbSTA==",
+          "dev": true,
+          "requires": {
+            "warning": "3.0.0"
+          }
+        },
+        "jss-preset-default": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/jss-preset-default/-/jss-preset-default-4.1.0.tgz",
+          "integrity": "sha512-C6SyfDg99EFrt0bv0lsg2OEN3e72Fry9/hMPW2sO6MSVsx+vc/Og6TJJY3F2MY5Z/V2/wlARHVmCb3TYMr0zFA==",
+          "dev": true,
+          "requires": {
+            "jss-camel-case": "6.0.0",
+            "jss-compose": "5.0.0",
+            "jss-default-unit": "8.0.2",
+            "jss-expand": "5.1.0",
+            "jss-extend": "6.1.0",
+            "jss-global": "3.0.0",
+            "jss-nested": "6.0.1",
+            "jss-props-sort": "6.0.0",
+            "jss-template": "1.0.1",
+            "jss-vendor-prefixer": "7.0.0"
+          }
+        },
+        "jss-props-sort": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/jss-props-sort/-/jss-props-sort-6.0.0.tgz",
+          "integrity": "sha512-E89UDcrphmI0LzmvYk25Hp4aE5ZBsXqMWlkFXS0EtPkunJkRr+WXdCNYbXbksIPnKlBenGB9OxzQY+mVc70S+g==",
+          "dev": true
+        },
+        "jss-vendor-prefixer": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/jss-vendor-prefixer/-/jss-vendor-prefixer-7.0.0.tgz",
+          "integrity": "sha512-Agd+FKmvsI0HLcYXkvy8GYOw3AAASBUpsmIRvVQheps+JWaN892uFOInTr0DRydwaD91vSSUCU4NssschvF7MA==",
+          "dev": true,
+          "requires": {
+            "css-vendor": "0.3.8"
+          }
+        },
+        "normalize-scroll-left": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/normalize-scroll-left/-/normalize-scroll-left-0.1.2.tgz",
+          "integrity": "sha512-F9YMRls0zCF6BFIE2YnXDRpHPpfd91nOIaNdDgrx5YMoPLo8Wqj+6jNXHQsYBavJeXP4ww8HCt0xQAKc5qk2Fg==",
+          "dev": true
+        },
+        "react-jss": {
+          "version": "8.2.1",
+          "resolved": "https://registry.npmjs.org/react-jss/-/react-jss-8.2.1.tgz",
+          "integrity": "sha512-H1fm32xG8pi4LMHkXjqpLyFOvSDsravd0HI6Dtlb/iyma1tfi7qqqSH2bf0kKyTAJV5hvYL0ls0qvRJWKfDPcA==",
+          "dev": true,
+          "requires": {
+            "hoist-non-react-statics": "2.3.1",
+            "jss": "9.5.1",
+            "jss-preset-default": "4.1.0",
+            "prop-types": "15.6.0",
+            "theming": "1.3.0"
+          }
+        },
+        "react-popper": {
+          "version": "0.7.5",
+          "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-0.7.5.tgz",
+          "integrity": "sha512-ya9dhhGCf74JTOB2uyksEHhIGw7w9tNZRUJF73lEq2h4H5JT6MBa4PdT4G+sx6fZwq+xKZAL/sVNAIuojPn7Dg==",
+          "dev": true,
+          "requires": {
+            "popper.js": "1.12.5",
+            "prop-types": "15.6.0"
+          }
+        },
+        "symbol-observable": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.1.0.tgz",
+          "integrity": "sha512-dQoid9tqQ+uotGhuTKEY11X4xhyYePVnqGSoSm3OGKh2E8LZ6RPULp1uXTctk33IeERlrRJYoVSBglsL05F5Uw==",
+          "dev": true
+        },
+        "theming": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/theming/-/theming-1.3.0.tgz",
+          "integrity": "sha512-ya5Ef7XDGbTPBv5ENTwrwkPUexrlPeiAg/EI9kdlUAZhNlRbCdhMKRgjNX1IcmsmiPcqDQZE6BpSaH+cr31FKw==",
+          "dev": true,
+          "requires": {
+            "brcast": "3.0.1",
+            "is-function": "1.0.1",
+            "is-plain-object": "2.0.4",
+            "prop-types": "15.6.0"
+          }
+        }
       }
     },
     "math-expression-evaluator": {
@@ -9175,12 +9293,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
       "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
-      "dev": true
-    },
-    "normalize-scroll-left": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/normalize-scroll-left/-/normalize-scroll-left-0.1.1.tgz",
-      "integrity": "sha512-mVtCk5KSIpcbNVDAphXZi9jzktcb4fJyAxBa92UDvnGtZ6Ht1IaedGaxTaa20DQlKdOBu5Asg49phBZy/a2xxw==",
       "dev": true
     },
     "normalize-url": {
@@ -12447,12 +12559,6 @@
         "warning": "3.0.0"
       }
     },
-    "react-flow-types": {
-      "version": "0.2.0-beta.2",
-      "resolved": "https://registry.npmjs.org/react-flow-types/-/react-flow-types-0.2.0-beta.2.tgz",
-      "integrity": "sha512-KmJZbfATfrfWUK5SbzEqWJSzO/ZHPyG69O5BH42twtdz4XNTTR7hTGCyUbGit6yTujzdg/SPSaPsSRQWptKBaw==",
-      "dev": true
-    },
     "react-group": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/react-group/-/react-group-1.0.5.tgz",
@@ -12496,19 +12602,6 @@
         "is-dom": "1.0.9"
       }
     },
-    "react-jss": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/react-jss/-/react-jss-7.2.0.tgz",
-      "integrity": "sha512-vgnNFImsjfchBloCt0BCe7MeiNEiGtTm/MGA0RVFjU/ccTt+YAlfFhSlGJ+KOC3qQ9Sl5mkl07JatGfjW2CTQQ==",
-      "dev": true,
-      "requires": {
-        "hoist-non-react-statics": "1.2.0",
-        "jss": "8.1.0",
-        "jss-preset-default": "3.0.0",
-        "prop-types": "15.6.0",
-        "theming": "1.1.0"
-      }
-    },
     "react-komposer": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/react-komposer/-/react-komposer-2.0.0.tgz",
@@ -12529,16 +12622,6 @@
       "dev": true,
       "requires": {
         "exenv": "1.2.2",
-        "prop-types": "15.6.0"
-      }
-    },
-    "react-popper": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-0.7.3.tgz",
-      "integrity": "sha512-uYVfJdEoZqwNXB1suaEITnpo+AQRVU9xZ3E41ufz3/PV/qmDfsa6VV6ppQZxUHVrEnHEOwoefXn/+D1/fGOUKg==",
-      "dev": true,
-      "requires": {
-        "popper.js": "1.12.5",
         "prop-types": "15.6.0"
       }
     },
@@ -13300,12 +13383,6 @@
         "lodash.flattendeep": "4.4.0",
         "nearley": "2.11.0"
       }
-    },
-    "rtl-css-js": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/rtl-css-js/-/rtl-css-js-1.7.0.tgz",
-      "integrity": "sha512-wQTxRhwAwpV6lnACU3S2rdheRy2wsXrcPfqhq/KQ4tFXPzCYBHT8Vqmz6fiA1xJ5DOOg4LzCi/e4yAlGdmKwdg==",
-      "dev": true
     },
     "run-async": {
       "version": "0.1.0",
@@ -14267,15 +14344,6 @@
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-length": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
@@ -14356,6 +14424,15 @@
         "define-properties": "1.1.2",
         "es-abstract": "1.9.0",
         "function-bind": "1.1.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringify-entities": {
@@ -14650,40 +14727,6 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
-    },
-    "theming": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/theming/-/theming-1.1.0.tgz",
-      "integrity": "sha512-YRhQV+eqeuef70eqfMGKGR+3DBXoWJ4lsrSSuj8dzrv0/EsnVuDmZAjIifESvJARtuP1KbMpdl8qbXdLAz4t/w==",
-      "dev": true,
-      "requires": {
-        "brcast": "2.0.2",
-        "is-function": "1.0.1",
-        "is-plain-object": "2.0.4",
-        "prop-types": "15.6.0",
-        "react": "15.6.2"
-      },
-      "dependencies": {
-        "brcast": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/brcast/-/brcast-2.0.2.tgz",
-          "integrity": "sha512-Tfn5JSE7hrUlFcOoaLzVvkbgIemIorMIyoMr3TgvszWW7jFt2C9PdeMLtysYD9RU0MmU17b69+XJG1eRY2OBRg==",
-          "dev": true
-        },
-        "react": {
-          "version": "15.6.2",
-          "resolved": "https://registry.npmjs.org/react/-/react-15.6.2.tgz",
-          "integrity": "sha1-26BDSrQ5z+gvEI8PURZjkIF5qnI=",
-          "dev": true,
-          "requires": {
-            "create-react-class": "15.6.2",
-            "fbjs": "0.8.16",
-            "loose-envify": "1.3.1",
-            "object-assign": "4.1.1",
-            "prop-types": "15.6.0"
-          }
-        }
-      }
     },
     "throat": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "enzyme-to-json": "^3.1.2",
     "gh-pages": "^1.0.0",
     "jest": "^21.2.1",
-    "material-ui": "^1.0.0-beta.16",
+    "material-ui": "^1.0.0-beta.30",
     "mockdate": "^2.0.2",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",

--- a/src/Clock.js
+++ b/src/Clock.js
@@ -34,7 +34,7 @@ const styles = (theme) => ({
     pointerEvents: 'none',
     userSelect: 'none',
     '&.selected': {
-      color: getContrastRatio(theme.palette.primary[500], theme.palette.common.fullBlack) < 7 ? theme.palette.common.fullWhite : theme.palette.common.fullBlack
+      color: getContrastRatio(theme.palette.primary.main, theme.palette.common.fullBlack) < 7 ? theme.palette.common.fullWhite : theme.palette.common.fullBlack
     }
   },
   smallNumber: {
@@ -44,7 +44,7 @@ const styles = (theme) => ({
   pointer: {
     width: 'calc(50% - 20px)',
     height: 2,
-    backgroundColor: theme.palette.primary[500],
+    backgroundColor: theme.palette.primary.main,
     position: 'absolute',
     left: '50%',
     top: 'calc(50% - 1px)',
@@ -58,7 +58,7 @@ const styles = (theme) => ({
     width: 'calc(50% - 52px)'
   },
   innerDot: {
-    backgroundColor: theme.palette.primary[500],
+    backgroundColor: theme.palette.primary.main,
     position: 'absolute',
     top: -4 + 1,
     left: -4,
@@ -67,7 +67,7 @@ const styles = (theme) => ({
     borderRadius: '50%'
   },
   outerDot: {
-    border: `16px solid ${theme.palette.primary[500]}`,
+    border: `16px solid ${theme.palette.primary.main}`,
     borderWidth: 16,
     position: 'absolute',
     top: -16 + 1,
@@ -78,7 +78,7 @@ const styles = (theme) => ({
     boxSizing: 'content-box'
   },
   outerDotOdd: {
-    background: getContrastRatio(theme.palette.primary[500], theme.palette.common.fullBlack) < 7 ? theme.palette.common.fullWhite : theme.palette.common.fullBlack,
+    background: getContrastRatio(theme.palette.primary.main, theme.palette.common.fullBlack) < 7 ? theme.palette.common.fullWhite : theme.palette.common.fullBlack,
     width: 4,
     height: 4,
     borderWidth: 14

--- a/src/TimePicker.js
+++ b/src/TimePicker.js
@@ -13,8 +13,8 @@ const styles = (theme) => ({
     fontFamily: theme.typography.fontFamily
   },
   header: {
-    background: theme.palette.primary[500],
-    color: getContrastRatio(theme.palette.primary[500], theme.palette.common.lightBlack) < 7 ? theme.palette.common.lightWhite : theme.palette.common.lightBlack,
+    background: theme.palette.primary.main,
+    color: getContrastRatio(theme.palette.primary.main, theme.palette.common.fullBlack) < 7 ? theme.palette.common.fullWhite : theme.palette.common.fullBlack,
     padding: '20px 0',
     lineHeight: '58px',
     fontSize: '58px',
@@ -40,7 +40,7 @@ const styles = (theme) => ({
     fontWeight: 700
   },
   select: {
-    color: getContrastRatio(theme.palette.primary[500], theme.palette.common.fullBlack) < 7 ? theme.palette.common.fullWhite : theme.palette.common.fullBlack
+    color: getContrastRatio(theme.palette.primary.main, theme.palette.common.fullBlack) < 7 ? theme.palette.common.fullWhite : theme.palette.common.fullBlack
   },
   body: {
     padding: '24px 16px',

--- a/src/__snapshots__/Clock.spec.js.snap
+++ b/src/__snapshots__/Clock.spec.js.snap
@@ -1,14 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Clock /> 12h matches the snapshot 1`] = `
-<withStyles(Clock)
+<WithStyles(Clock)
   mode="12h"
   value={7}
 >
   <Clock
     classes={
       Object {
-        ".Clock-number-3.selected": "Clock-number-3.selected",
         "animatedPointer": "Clock-animatedPointer-6",
         "circle": "Clock-circle-2",
         "innerDot": "Clock-innerDot-8",
@@ -187,18 +186,17 @@ exports[`<Clock /> 12h matches the snapshot 1`] = `
       </div>
     </div>
   </Clock>
-</withStyles(Clock)>
+</WithStyles(Clock)>
 `;
 
 exports[`<Clock /> 24h matches the snapshot 1`] = `
-<withStyles(Clock)
+<WithStyles(Clock)
   mode="24h"
   value={7}
 >
   <Clock
     classes={
       Object {
-        ".Clock-number-3.selected": "Clock-number-3.selected",
         "animatedPointer": "Clock-animatedPointer-6",
         "circle": "Clock-circle-2",
         "innerDot": "Clock-innerDot-8",
@@ -509,18 +507,17 @@ exports[`<Clock /> 24h matches the snapshot 1`] = `
       </div>
     </div>
   </Clock>
-</withStyles(Clock)>
+</WithStyles(Clock)>
 `;
 
 exports[`<Clock /> minutes matches the snapshot 1`] = `
-<withStyles(Clock)
+<WithStyles(Clock)
   mode="minutes"
   value={42}
 >
   <Clock
     classes={
       Object {
-        ".Clock-number-3.selected": "Clock-number-3.selected",
         "animatedPointer": "Clock-animatedPointer-6",
         "circle": "Clock-circle-2",
         "innerDot": "Clock-innerDot-8",
@@ -699,5 +696,5 @@ exports[`<Clock /> minutes matches the snapshot 1`] = `
       </div>
     </div>
   </Clock>
-</withStyles(Clock)>
+</WithStyles(Clock)>
 `;

--- a/src/__snapshots__/TimeInput.spec.js.snap
+++ b/src/__snapshots__/TimeInput.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<TimeInput /> 12h matches the snapshot 1`] = `
-<withStyles(TimeInput)
+<WithStyles(TimeInput)
   defaultValue={2017-10-15T13:37:00.000Z}
   mode="12h"
 >
@@ -18,7 +18,7 @@ exports[`<TimeInput /> 12h matches the snapshot 1`] = `
     mode="12h"
     okLabel="Ok"
   >
-    <withStyles(Input)
+    <WithStyles(Input)
       disabled={false}
       key="TimeInput-input"
       onClick={[Function]}
@@ -28,44 +28,21 @@ exports[`<TimeInput /> 12h matches the snapshot 1`] = `
       <Input
         classes={
           Object {
-            ".MuiInput-error-6:after": "MuiInput-error-6:after",
-            ".MuiInput-inkbar-5.MuiInput-focused-10:after": "MuiInput-inkbar-5.MuiInput-focused-10:after",
-            ".MuiInput-inkbar-5:after": "MuiInput-inkbar-5:after",
-            ".MuiInput-input-7:-ms-input-placeholder": "MuiInput-input-7:-ms-input-placeholder",
-            ".MuiInput-input-7::-moz-placeholder": "MuiInput-input-7::-moz-placeholder",
-            ".MuiInput-input-7::-ms-input-placeholder": "MuiInput-input-7::-ms-input-placeholder",
-            ".MuiInput-input-7::-webkit-input-placeholder": "MuiInput-input-7::-webkit-input-placeholder",
-            ".MuiInput-input-7::-webkit-search-decoration": "MuiInput-input-7::-webkit-search-decoration",
-            ".MuiInput-input-7:focus": "MuiInput-input-7:focus",
-            ".MuiInput-input-7:invalid": "MuiInput-input-7:invalid",
-            ".MuiInput-underline-11.MuiInput-disabled-9:before": "MuiInput-underline-11.MuiInput-disabled-9:before",
-            ".MuiInput-underline-11:before": "MuiInput-underline-11:before",
-            ".MuiInput-underline-11:hover:not(.MuiInput-disabled-9):before": "MuiInput-underline-11:hover:not(.MuiInput-disabled-9):before",
-            "disabled": "MuiInput-disabled-9",
+            "disabled": "MuiInput-disabled-8",
             "error": "MuiInput-error-6",
-            "focused": "MuiInput-focused-10",
+            "focused": "MuiInput-focused-7",
             "formControl": "MuiInput-formControl-4",
-            "fullWidth": "MuiInput-fullWidth-17",
+            "fullWidth": "MuiInput-fullWidth-11",
             "inkbar": "MuiInput-inkbar-5",
-            "input": "MuiInput-input-7",
-            "inputDense": "MuiInput-inputDense-8",
-            "inputDisabled": "MuiInput-inputDisabled-13",
+            "input": "MuiInput-input-12",
+            "inputDense": "MuiInput-inputDense-13",
+            "inputDisabled": "MuiInput-inputDisabled-14",
             "inputMultiline": "MuiInput-inputMultiline-16",
-            "inputSearch": "MuiInput-inputSearch-15",
-            "inputSingleline": "MuiInput-inputSingleline-14",
-            "label + .MuiInput-formControl-4": "abel + .MuiInput-formControl-4",
-            "label[data-shrink=false] + .MuiInput-formControl-4 .MuiInput-input-7": "abel[data-shrink=false] + .MuiInput-formControl-4 .MuiInput-input-7",
-            "label[data-shrink=false] + .MuiInput-formControl-4 .MuiInput-input-7:-ms-input-placeholder": "abel[data-shrink=false] + .MuiInput-formControl-4 .MuiInput-input-7:-ms-input-placeholder",
-            "label[data-shrink=false] + .MuiInput-formControl-4 .MuiInput-input-7::-moz-placeholder": "abel[data-shrink=false] + .MuiInput-formControl-4 .MuiInput-input-7::-moz-placeholder",
-            "label[data-shrink=false] + .MuiInput-formControl-4 .MuiInput-input-7::-ms-input-placeholder": "abel[data-shrink=false] + .MuiInput-formControl-4 .MuiInput-input-7::-ms-input-placeholder",
-            "label[data-shrink=false] + .MuiInput-formControl-4 .MuiInput-input-7::-webkit-input-placeholder": "abel[data-shrink=false] + .MuiInput-formControl-4 .MuiInput-input-7::-webkit-input-placeholder",
-            "label[data-shrink=false] + .MuiInput-formControl-4 .MuiInput-input-7:focus:-ms-input-placeholder": "abel[data-shrink=false] + .MuiInput-formControl-4 .MuiInput-input-7:focus:-ms-input-placeholder",
-            "label[data-shrink=false] + .MuiInput-formControl-4 .MuiInput-input-7:focus::-moz-placeholder": "abel[data-shrink=false] + .MuiInput-formControl-4 .MuiInput-input-7:focus::-moz-placeholder",
-            "label[data-shrink=false] + .MuiInput-formControl-4 .MuiInput-input-7:focus::-ms-input-placeholder": "abel[data-shrink=false] + .MuiInput-formControl-4 .MuiInput-input-7:focus::-ms-input-placeholder",
-            "label[data-shrink=false] + .MuiInput-formControl-4 .MuiInput-input-7:focus::-webkit-input-placeholder": "abel[data-shrink=false] + .MuiInput-formControl-4 .MuiInput-input-7:focus::-webkit-input-placeholder",
-            "multiline": "MuiInput-multiline-12",
+            "inputSearch": "MuiInput-inputSearch-17",
+            "inputSingleline": "MuiInput-inputSingleline-15",
+            "multiline": "MuiInput-multiline-10",
             "root": "MuiInput-root-3",
-            "underline": "MuiInput-underline-11",
+            "underline": "MuiInput-underline-9",
           }
         }
         disableUnderline={false}
@@ -78,15 +55,17 @@ exports[`<TimeInput /> 12h matches the snapshot 1`] = `
         value="1:37 pm"
       >
         <div
-          className="MuiInput-root-3 MuiInput-inkbar-5 MuiInput-underline-11"
+          className="MuiInput-root-3 MuiInput-inkbar-5 MuiInput-underline-9"
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
         >
           <input
+            aria-invalid={undefined}
+            aria-required={undefined}
             autoComplete={undefined}
             autoFocus={undefined}
-            className="MuiInput-input-7 MuiInput-inputSingleline-14"
+            className="MuiInput-input-12 MuiInput-inputSingleline-15"
             defaultValue={undefined}
             disabled={false}
             id={undefined}
@@ -103,8 +82,8 @@ exports[`<TimeInput /> 12h matches the snapshot 1`] = `
           />
         </div>
       </Input>
-    </withStyles(Input)>
-    <withStyles(Dialog)
+    </WithStyles(Input)>
+    <WithStyles(Dialog)
       key="TimeInput-dialog"
       maxWidth="xs"
       onRequestClose={[Function]}
@@ -113,7 +92,6 @@ exports[`<TimeInput /> 12h matches the snapshot 1`] = `
       <Dialog
         classes={
           Object {
-            ".MuiDialog-paper-19:focus": "MuiDialog-paper-19:focus",
             "fullScreen": "MuiDialog-fullScreen-24",
             "fullWidth": "MuiDialog-fullWidth-23",
             "paper": "MuiDialog-paper-19",
@@ -123,10 +101,10 @@ exports[`<TimeInput /> 12h matches the snapshot 1`] = `
             "root": "MuiDialog-root-18",
           }
         }
+        disableBackdropClick={false}
+        disableEscapeKeyDown={false}
         fullScreen={false}
         fullWidth={false}
-        ignoreBackdropClick={false}
-        ignoreEscapeKeyUp={false}
         maxWidth="xs"
         onRequestClose={[Function]}
         open={false}
@@ -138,28 +116,33 @@ exports[`<TimeInput /> 12h matches the snapshot 1`] = `
           }
         }
       >
-        <withStyles(Modal)
-          backdropTransitionDuration={
+        <WithStyles(Modal)
+          BackdropProps={
             Object {
-              "enter": 225,
-              "exit": 195,
+              "transitionDuration": Object {
+                "enter": 225,
+                "exit": 195,
+              },
             }
           }
           className="MuiDialog-root-18"
-          ignoreBackdropClick={false}
-          ignoreEscapeKeyUp={false}
+          disableBackdropClick={false}
+          disableEscapeKeyDown={false}
           onBackdropClick={undefined}
-          onEscapeKeyUp={undefined}
+          onClose={undefined}
+          onEscapeKeyDown={undefined}
           onRequestClose={[Function]}
-          show={false}
+          open={false}
+          role="dialog"
         >
           <Modal
-            backdropComponent={[Function]}
-            backdropInvisible={false}
-            backdropTransitionDuration={
+            BackdropComponent={[Function]}
+            BackdropProps={
               Object {
-                "enter": 225,
-                "exit": 195,
+                "transitionDuration": Object {
+                  "enter": 225,
+                  "exit": 195,
+                },
               }
             }
             className="MuiDialog-root-18"
@@ -169,31 +152,41 @@ exports[`<TimeInput /> 12h matches the snapshot 1`] = `
                 "root": "MuiModal-root-25",
               }
             }
-            disableBackdrop={false}
-            ignoreBackdropClick={false}
-            ignoreEscapeKeyUp={false}
+            disableAutoFocus={false}
+            disableBackdropClick={false}
+            disableEnforceFocus={false}
+            disableEscapeKeyDown={false}
+            disableRestoreFocus={false}
+            hideBackdrop={false}
             keepMounted={false}
-            modalManager={
-              Object {
+            manager={
+              ModalManager {
                 "add": [Function],
+                "containers": Array [],
+                "data": Array [],
+                "handleContainerOverflow": true,
+                "hideSiblingNodes": true,
                 "isTopModal": [Function],
+                "modals": Array [],
                 "remove": [Function],
               }
             }
             onBackdropClick={undefined}
-            onEscapeKeyUp={undefined}
+            onClose={undefined}
+            onEscapeKeyDown={undefined}
             onRequestClose={[Function]}
-            show={false}
+            open={false}
+            role="dialog"
           />
-        </withStyles(Modal)>
+        </WithStyles(Modal)>
       </Dialog>
-    </withStyles(Dialog)>
+    </WithStyles(Dialog)>
   </TimeInput>
-</withStyles(TimeInput)>
+</WithStyles(TimeInput)>
 `;
 
 exports[`<TimeInput /> 24h matches the snapshot 1`] = `
-<withStyles(TimeInput)
+<WithStyles(TimeInput)
   defaultValue={2017-10-15T13:37:00.000Z}
   mode="24h"
 >
@@ -210,7 +203,7 @@ exports[`<TimeInput /> 24h matches the snapshot 1`] = `
     mode="24h"
     okLabel="Ok"
   >
-    <withStyles(Input)
+    <WithStyles(Input)
       disabled={false}
       key="TimeInput-input"
       onClick={[Function]}
@@ -220,44 +213,21 @@ exports[`<TimeInput /> 24h matches the snapshot 1`] = `
       <Input
         classes={
           Object {
-            ".MuiInput-error-6:after": "MuiInput-error-6:after",
-            ".MuiInput-inkbar-5.MuiInput-focused-10:after": "MuiInput-inkbar-5.MuiInput-focused-10:after",
-            ".MuiInput-inkbar-5:after": "MuiInput-inkbar-5:after",
-            ".MuiInput-input-7:-ms-input-placeholder": "MuiInput-input-7:-ms-input-placeholder",
-            ".MuiInput-input-7::-moz-placeholder": "MuiInput-input-7::-moz-placeholder",
-            ".MuiInput-input-7::-ms-input-placeholder": "MuiInput-input-7::-ms-input-placeholder",
-            ".MuiInput-input-7::-webkit-input-placeholder": "MuiInput-input-7::-webkit-input-placeholder",
-            ".MuiInput-input-7::-webkit-search-decoration": "MuiInput-input-7::-webkit-search-decoration",
-            ".MuiInput-input-7:focus": "MuiInput-input-7:focus",
-            ".MuiInput-input-7:invalid": "MuiInput-input-7:invalid",
-            ".MuiInput-underline-11.MuiInput-disabled-9:before": "MuiInput-underline-11.MuiInput-disabled-9:before",
-            ".MuiInput-underline-11:before": "MuiInput-underline-11:before",
-            ".MuiInput-underline-11:hover:not(.MuiInput-disabled-9):before": "MuiInput-underline-11:hover:not(.MuiInput-disabled-9):before",
-            "disabled": "MuiInput-disabled-9",
+            "disabled": "MuiInput-disabled-8",
             "error": "MuiInput-error-6",
-            "focused": "MuiInput-focused-10",
+            "focused": "MuiInput-focused-7",
             "formControl": "MuiInput-formControl-4",
-            "fullWidth": "MuiInput-fullWidth-17",
+            "fullWidth": "MuiInput-fullWidth-11",
             "inkbar": "MuiInput-inkbar-5",
-            "input": "MuiInput-input-7",
-            "inputDense": "MuiInput-inputDense-8",
-            "inputDisabled": "MuiInput-inputDisabled-13",
+            "input": "MuiInput-input-12",
+            "inputDense": "MuiInput-inputDense-13",
+            "inputDisabled": "MuiInput-inputDisabled-14",
             "inputMultiline": "MuiInput-inputMultiline-16",
-            "inputSearch": "MuiInput-inputSearch-15",
-            "inputSingleline": "MuiInput-inputSingleline-14",
-            "label + .MuiInput-formControl-4": "abel + .MuiInput-formControl-4",
-            "label[data-shrink=false] + .MuiInput-formControl-4 .MuiInput-input-7": "abel[data-shrink=false] + .MuiInput-formControl-4 .MuiInput-input-7",
-            "label[data-shrink=false] + .MuiInput-formControl-4 .MuiInput-input-7:-ms-input-placeholder": "abel[data-shrink=false] + .MuiInput-formControl-4 .MuiInput-input-7:-ms-input-placeholder",
-            "label[data-shrink=false] + .MuiInput-formControl-4 .MuiInput-input-7::-moz-placeholder": "abel[data-shrink=false] + .MuiInput-formControl-4 .MuiInput-input-7::-moz-placeholder",
-            "label[data-shrink=false] + .MuiInput-formControl-4 .MuiInput-input-7::-ms-input-placeholder": "abel[data-shrink=false] + .MuiInput-formControl-4 .MuiInput-input-7::-ms-input-placeholder",
-            "label[data-shrink=false] + .MuiInput-formControl-4 .MuiInput-input-7::-webkit-input-placeholder": "abel[data-shrink=false] + .MuiInput-formControl-4 .MuiInput-input-7::-webkit-input-placeholder",
-            "label[data-shrink=false] + .MuiInput-formControl-4 .MuiInput-input-7:focus:-ms-input-placeholder": "abel[data-shrink=false] + .MuiInput-formControl-4 .MuiInput-input-7:focus:-ms-input-placeholder",
-            "label[data-shrink=false] + .MuiInput-formControl-4 .MuiInput-input-7:focus::-moz-placeholder": "abel[data-shrink=false] + .MuiInput-formControl-4 .MuiInput-input-7:focus::-moz-placeholder",
-            "label[data-shrink=false] + .MuiInput-formControl-4 .MuiInput-input-7:focus::-ms-input-placeholder": "abel[data-shrink=false] + .MuiInput-formControl-4 .MuiInput-input-7:focus::-ms-input-placeholder",
-            "label[data-shrink=false] + .MuiInput-formControl-4 .MuiInput-input-7:focus::-webkit-input-placeholder": "abel[data-shrink=false] + .MuiInput-formControl-4 .MuiInput-input-7:focus::-webkit-input-placeholder",
-            "multiline": "MuiInput-multiline-12",
+            "inputSearch": "MuiInput-inputSearch-17",
+            "inputSingleline": "MuiInput-inputSingleline-15",
+            "multiline": "MuiInput-multiline-10",
             "root": "MuiInput-root-3",
-            "underline": "MuiInput-underline-11",
+            "underline": "MuiInput-underline-9",
           }
         }
         disableUnderline={false}
@@ -270,15 +240,17 @@ exports[`<TimeInput /> 24h matches the snapshot 1`] = `
         value="13:37"
       >
         <div
-          className="MuiInput-root-3 MuiInput-inkbar-5 MuiInput-underline-11"
+          className="MuiInput-root-3 MuiInput-inkbar-5 MuiInput-underline-9"
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
         >
           <input
+            aria-invalid={undefined}
+            aria-required={undefined}
             autoComplete={undefined}
             autoFocus={undefined}
-            className="MuiInput-input-7 MuiInput-inputSingleline-14"
+            className="MuiInput-input-12 MuiInput-inputSingleline-15"
             defaultValue={undefined}
             disabled={false}
             id={undefined}
@@ -295,8 +267,8 @@ exports[`<TimeInput /> 24h matches the snapshot 1`] = `
           />
         </div>
       </Input>
-    </withStyles(Input)>
-    <withStyles(Dialog)
+    </WithStyles(Input)>
+    <WithStyles(Dialog)
       key="TimeInput-dialog"
       maxWidth="xs"
       onRequestClose={[Function]}
@@ -305,7 +277,6 @@ exports[`<TimeInput /> 24h matches the snapshot 1`] = `
       <Dialog
         classes={
           Object {
-            ".MuiDialog-paper-19:focus": "MuiDialog-paper-19:focus",
             "fullScreen": "MuiDialog-fullScreen-24",
             "fullWidth": "MuiDialog-fullWidth-23",
             "paper": "MuiDialog-paper-19",
@@ -315,10 +286,10 @@ exports[`<TimeInput /> 24h matches the snapshot 1`] = `
             "root": "MuiDialog-root-18",
           }
         }
+        disableBackdropClick={false}
+        disableEscapeKeyDown={false}
         fullScreen={false}
         fullWidth={false}
-        ignoreBackdropClick={false}
-        ignoreEscapeKeyUp={false}
         maxWidth="xs"
         onRequestClose={[Function]}
         open={false}
@@ -330,28 +301,33 @@ exports[`<TimeInput /> 24h matches the snapshot 1`] = `
           }
         }
       >
-        <withStyles(Modal)
-          backdropTransitionDuration={
+        <WithStyles(Modal)
+          BackdropProps={
             Object {
-              "enter": 225,
-              "exit": 195,
+              "transitionDuration": Object {
+                "enter": 225,
+                "exit": 195,
+              },
             }
           }
           className="MuiDialog-root-18"
-          ignoreBackdropClick={false}
-          ignoreEscapeKeyUp={false}
+          disableBackdropClick={false}
+          disableEscapeKeyDown={false}
           onBackdropClick={undefined}
-          onEscapeKeyUp={undefined}
+          onClose={undefined}
+          onEscapeKeyDown={undefined}
           onRequestClose={[Function]}
-          show={false}
+          open={false}
+          role="dialog"
         >
           <Modal
-            backdropComponent={[Function]}
-            backdropInvisible={false}
-            backdropTransitionDuration={
+            BackdropComponent={[Function]}
+            BackdropProps={
               Object {
-                "enter": 225,
-                "exit": 195,
+                "transitionDuration": Object {
+                  "enter": 225,
+                  "exit": 195,
+                },
               }
             }
             className="MuiDialog-root-18"
@@ -361,25 +337,35 @@ exports[`<TimeInput /> 24h matches the snapshot 1`] = `
                 "root": "MuiModal-root-25",
               }
             }
-            disableBackdrop={false}
-            ignoreBackdropClick={false}
-            ignoreEscapeKeyUp={false}
+            disableAutoFocus={false}
+            disableBackdropClick={false}
+            disableEnforceFocus={false}
+            disableEscapeKeyDown={false}
+            disableRestoreFocus={false}
+            hideBackdrop={false}
             keepMounted={false}
-            modalManager={
-              Object {
+            manager={
+              ModalManager {
                 "add": [Function],
+                "containers": Array [],
+                "data": Array [],
+                "handleContainerOverflow": true,
+                "hideSiblingNodes": true,
                 "isTopModal": [Function],
+                "modals": Array [],
                 "remove": [Function],
               }
             }
             onBackdropClick={undefined}
-            onEscapeKeyUp={undefined}
+            onClose={undefined}
+            onEscapeKeyDown={undefined}
             onRequestClose={[Function]}
-            show={false}
+            open={false}
+            role="dialog"
           />
-        </withStyles(Modal)>
+        </WithStyles(Modal)>
       </Dialog>
-    </withStyles(Dialog)>
+    </WithStyles(Dialog)>
   </TimeInput>
-</withStyles(TimeInput)>
+</WithStyles(TimeInput)>
 `;

--- a/src/__snapshots__/TimePicker.spec.js.snap
+++ b/src/__snapshots__/TimePicker.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<TimePicker /> 12h matches the snapshot 1`] = `
-<withStyles(TimePicker)
+<WithStyles(TimePicker)
   mode="12h"
   value={2017-10-15T13:37:00.000Z}
 >
@@ -64,7 +64,7 @@ exports[`<TimePicker /> 12h matches the snapshot 1`] = `
       <div
         className="TimePicker-body-7"
       >
-        <withStyles(Clock)
+        <WithStyles(Clock)
           mode="12h"
           onChange={[Function]}
           onMouseUp={[Function]}
@@ -74,7 +74,6 @@ exports[`<TimePicker /> 12h matches the snapshot 1`] = `
           <Clock
             classes={
               Object {
-                ".Clock-number-10.selected": "Clock-number-10.selected",
                 "animatedPointer": "Clock-animatedPointer-13",
                 "circle": "Clock-circle-9",
                 "innerDot": "Clock-innerDot-15",
@@ -259,15 +258,15 @@ exports[`<TimePicker /> 12h matches the snapshot 1`] = `
               </div>
             </div>
           </Clock>
-        </withStyles(Clock)>
+        </WithStyles(Clock)>
       </div>
     </div>
   </TimePicker>
-</withStyles(TimePicker)>
+</WithStyles(TimePicker)>
 `;
 
 exports[`<TimePicker /> 24h matches the snapshot 1`] = `
-<withStyles(TimePicker)
+<WithStyles(TimePicker)
   mode="24h"
   value={2017-10-15T13:37:00.000Z}
 >
@@ -317,7 +316,7 @@ exports[`<TimePicker /> 24h matches the snapshot 1`] = `
       <div
         className="TimePicker-body-7"
       >
-        <withStyles(Clock)
+        <WithStyles(Clock)
           mode="24h"
           onChange={[Function]}
           onMouseUp={[Function]}
@@ -327,7 +326,6 @@ exports[`<TimePicker /> 24h matches the snapshot 1`] = `
           <Clock
             classes={
               Object {
-                ".Clock-number-10.selected": "Clock-number-10.selected",
                 "animatedPointer": "Clock-animatedPointer-13",
                 "circle": "Clock-circle-9",
                 "innerDot": "Clock-innerDot-15",
@@ -644,9 +642,9 @@ exports[`<TimePicker /> 24h matches the snapshot 1`] = `
               </div>
             </div>
           </Clock>
-        </withStyles(Clock)>
+        </WithStyles(Clock)>
       </div>
     </div>
   </TimePicker>
-</withStyles(TimePicker)>
+</WithStyles(TimePicker)>
 `;


### PR DESCRIPTION
The color palette of material ui was recently revamped in v1.0.0-beta.30.
The light tint does not exist anymore and the mui favors using the default tint.

Instead of going 💥 , we should favor the default tint for black and white that come from the palette.

Related PR :

https://github.com/mui-org/material-ui/pull/9876
https://github.com/mui-org/material-ui/pull/9918
https://github.com/mui-org/material-ui/pull/9970